### PR TITLE
Modified Che to allow shared home folders in a namespace

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
@@ -152,7 +152,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
 
     // Note that PVC name is used during prefixing
     // It MUST be done before changing all PVCs references to common PVC
-    subpathPrefixes.prefixVolumeMountsSubpaths(k8sEnv, identity.getWorkspaceId());
+    subpathPrefixes.prefixVolumeMountsSubpaths(k8sEnv, identity.getWorkspaceId(), identity.getInfrastructureNamespace());
 
     PersistentVolumeClaim commonPVC = replacePVCsWithCommon(k8sEnv, identity);
 


### PR DESCRIPTION
Current deployed in ops. It allows workspaces to share the same persistent volume so that, for example, a user's `/projects` directory is the same across all workspaces. The code makes a distinction between user files and workspace logs files. Workspace log will always reside in a separate directory so that logs don't overwrite each other.

In order for this to deploy properly, need to follow the new deployment procedures that uses a single namespace for all workspaces under a user.